### PR TITLE
Update the volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - SOLR_SSL_TRUST_STORE_PASSWORD=123SecureSolr!
     volumes:
       - ./certs:/opt/solr/server/certs
-      - ./solr_home:/opt/solr/server/solr
+      - ./solr_home:/var/solr/data
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
I was getting errors trying to install sitecore 9.3.  This was because the cores where being copied to my solr_home directory but when the create core command was sent to solr it was looking in var/solr/data for the config.